### PR TITLE
i2c: Fix for compatibility with recent Linux kernels

### DIFF
--- a/cmd/fantrayd/fantrayd_rw.go
+++ b/cmd/fantrayd/fantrayd_rw.go
@@ -20,19 +20,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}
@@ -55,7 +55,7 @@ func (r *reg16) offset() uint8  { return uint8(uintptr(unsafe.Pointer(r)) - regs
 func (r *reg16r) offset() uint8 { return uint8(uintptr(unsafe.Pointer(r)) - regsAddr) }
 
 func closeMux(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(0)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -64,7 +64,7 @@ func closeMux(h *I2cDev) {
 }
 
 func (r *reg8) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -74,7 +74,7 @@ func (r *reg8) get(h *I2cDev) {
 }
 
 func (r *reg16) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -84,7 +84,7 @@ func (r *reg16) get(h *I2cDev) {
 }
 
 func (r *reg16r) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -94,7 +94,7 @@ func (r *reg16r) get(h *I2cDev) {
 }
 
 func (r *reg8) set(h *I2cDev, v uint8) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -105,7 +105,7 @@ func (r *reg8) set(h *I2cDev, v uint8) {
 }
 
 func (r *reg16) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -117,7 +117,7 @@ func (r *reg16) set(h *I2cDev, v uint16) {
 }
 
 func (r *reg16r) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -136,7 +136,7 @@ func clearJ() {
 }
 
 func readStopped() byte {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 	j[0] = I{true, i2c.Write, 0, i2c.ByteData, data, int(0x98), int(0), 0}
 	err := DoI2cRpc()
 	if err != nil {

--- a/cmd/fspd/fspd.go
+++ b/cmd/fspd/fspd.go
@@ -21,6 +21,7 @@ import (
 	"github.com/platinasystems/goes/cmd"
 	"github.com/platinasystems/goes/lang"
 	"github.com/platinasystems/gpio"
+	"github.com/platinasystems/i2c"
 	"github.com/platinasystems/log"
 	"github.com/platinasystems/redis"
 	"github.com/platinasystems/redis/publisher"
@@ -997,7 +998,7 @@ func (h *I2cDev) Eeprom() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		for k := 1; k < 33; k++ {
+		for k := 1; k < i2c.BlockMax; k++ {
 			v += fmt.Sprintf("%02x", s[1].D[k])
 		}
 	}

--- a/cmd/fspd/fspd_rw.go
+++ b/cmd/fspd/fspd_rw.go
@@ -20,19 +20,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}
@@ -63,7 +63,7 @@ func (r *reg16) offset() uint8  { return uint8((uintptr(unsafe.Pointer(r)) - reg
 func (r *reg16r) offset() uint8 { return uint8((uintptr(unsafe.Pointer(r)) - regsAddr) >> 1) }
 
 func closeMux(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(0)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 5}
@@ -72,7 +72,7 @@ func closeMux(h *I2cDev) {
 }
 
 func (r *reg8) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 5}
@@ -82,7 +82,7 @@ func (r *reg8) get(h *I2cDev) {
 }
 
 func (r *reg8b) get(h *I2cDev, readLen byte) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 5}
@@ -93,18 +93,18 @@ func (r *reg8b) get(h *I2cDev, readLen byte) {
 }
 
 func (r *reg32B) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 5}
 	x++
-	data[0] = 33
+	data[0] = i2c.BlockMax
 	j[x] = I{true, i2c.Read, r.offset(), i2c.I2CBlockData, data, h.Bus, h.AddrProm, 0}
 	x++
 }
 
 func (r *reg16) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 5}
@@ -114,7 +114,7 @@ func (r *reg16) get(h *I2cDev) {
 }
 
 func (r *reg16r) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 5}
@@ -124,7 +124,7 @@ func (r *reg16r) get(h *I2cDev) {
 }
 
 func (r *reg8) set(h *I2cDev, v uint8) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 5}
@@ -135,7 +135,7 @@ func (r *reg8) set(h *I2cDev, v uint8) {
 }
 
 func (r *reg16) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 5}
@@ -147,7 +147,7 @@ func (r *reg16) set(h *I2cDev, v uint16) {
 }
 
 func (r *reg16r) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 5}
@@ -166,7 +166,7 @@ func clearJ() {
 }
 
 func readStopped() byte {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 	j[0] = I{true, i2c.Write, 0, i2c.ByteData, data, int(0x98), int(0), 0}
 	err := DoI2cRpc()
 	if err != nil {
@@ -176,7 +176,7 @@ func readStopped() byte {
 }
 
 func stopI2c() error {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 	j[0] = I{true, i2c.Write, 0, 0, data, int(0x99), int(1), 0}
 	err := DoI2cRpc()
 	if err != nil {
@@ -186,7 +186,7 @@ func stopI2c() error {
 }
 
 func startI2c() error {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 	j[0] = I{true, i2c.Write, 0, 0, data, int(0x99), int(0), 0}
 	err := DoI2cRpc()
 	if err != nil {

--- a/cmd/i2c/i2c_rw.go
+++ b/cmd/i2c/i2c_rw.go
@@ -20,19 +20,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}

--- a/cmd/i2cd/i2cd.go
+++ b/cmd/i2cd/i2cd.go
@@ -82,13 +82,13 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
@@ -96,7 +96,7 @@ type I2cReq struct {
 	c *Command
 }
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}
@@ -176,7 +176,7 @@ func (t *I2cReq) ReadWrite(g *[MAXOPS]I, f *[MAXOPS]R) error {
 			f[x].D[0] = data[0]
 			f[x].D[1] = data[1]
 			if g[x].BusSize == i2c.I2CBlockData {
-				for y := 2; y < 34; y++ {
+				for y := 2; y < i2c.BlockMax; y++ {
 					f[x].D[y] = data[y]
 				}
 			}

--- a/cmd/platina/mk1/bmc/diag/diagI2c.go
+++ b/cmd/platina/mk1/bmc/diag/diagI2c.go
@@ -20,7 +20,7 @@ var j [MAXOPS]I
 var s [MAXOPS]R
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var x int
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var chassisType, boardType uint8
 
 const (
@@ -41,13 +41,13 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 

--- a/cmd/platina/mk1/bmc/ipcfg/ipcfg_rw.go
+++ b/cmd/platina/mk1/bmc/ipcfg/ipcfg_rw.go
@@ -19,19 +19,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}

--- a/cmd/platina/mk1/bmc/ledgpiod/ledgpiod_rw.go
+++ b/cmd/platina/mk1/bmc/ledgpiod/ledgpiod_rw.go
@@ -21,19 +21,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}
@@ -57,7 +57,7 @@ func (r *reg16) offset() uint8  { return uint8((uintptr(unsafe.Pointer(r)) - reg
 func (r *reg16r) offset() uint8 { return uint8((uintptr(unsafe.Pointer(r)) - regsAddr)) }
 
 func closeMux(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(0)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -66,7 +66,7 @@ func closeMux(h *I2cDev) {
 }
 
 func (r *reg8) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -76,7 +76,7 @@ func (r *reg8) get(h *I2cDev) {
 }
 
 func (r *reg16) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -86,7 +86,7 @@ func (r *reg16) get(h *I2cDev) {
 }
 
 func (r *reg16r) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -96,7 +96,7 @@ func (r *reg16r) get(h *I2cDev) {
 }
 
 func (r *reg8) set(h *I2cDev, v uint8) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -107,7 +107,7 @@ func (r *reg8) set(h *I2cDev, v uint8) {
 }
 
 func (r *reg16) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -119,7 +119,7 @@ func (r *reg16) set(h *I2cDev, v uint16) {
 }
 
 func (r *reg16r) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -138,7 +138,7 @@ func clearJ() {
 }
 
 func readStopped() byte {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 	j[0] = I{true, i2c.Write, 0, i2c.ByteData, data, int(0x98), int(0), 0}
 	err := DoI2cRpc()
 	if err != nil {

--- a/cmd/platina/mk1/bmc/ucd9090d/ucd9090d_rw.go
+++ b/cmd/platina/mk1/bmc/ucd9090d/ucd9090d_rw.go
@@ -21,19 +21,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}
@@ -57,7 +57,7 @@ func (r *reg16) offset() uint8  { return uint8((uintptr(unsafe.Pointer(r)) - reg
 func (r *reg16r) offset() uint8 { return uint8((uintptr(unsafe.Pointer(r)) - regsAddr) >> 1) }
 
 func closeMux(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(0)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -66,7 +66,7 @@ func closeMux(h *I2cDev) {
 }
 
 func (r *reg8) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -76,7 +76,7 @@ func (r *reg8) get(h *I2cDev) {
 }
 
 func (r *reg8b) get(h *I2cDev, readLen byte) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 5}
@@ -87,7 +87,7 @@ func (r *reg8b) get(h *I2cDev, readLen byte) {
 }
 
 func (r *reg16) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -97,7 +97,7 @@ func (r *reg16) get(h *I2cDev) {
 }
 
 func (r *reg16r) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -107,7 +107,7 @@ func (r *reg16r) get(h *I2cDev) {
 }
 
 func (r *reg8) set(h *I2cDev, v uint8) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -119,7 +119,7 @@ func (r *reg8) set(h *I2cDev, v uint8) {
 
 /*
 func (r *reg8b) set(h *I2cDev, v []byte) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -129,7 +129,7 @@ func (r *reg8b) set(h *I2cDev, v []byte) {
 }
 */
 func (r *reg16) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -141,7 +141,7 @@ func (r *reg16) set(h *I2cDev, v uint16) {
 }
 
 func (r *reg16r) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -160,7 +160,7 @@ func clearJ() {
 }
 
 func readStopped() byte {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 	j[0] = I{true, i2c.Write, 0, i2c.ByteData, data, int(0x98), int(0), 0}
 	err := DoI2cRpc()
 	if err != nil {

--- a/cmd/platina/mk1/bmc/upgrade/upgrade_rw.go
+++ b/cmd/platina/mk1/bmc/upgrade/upgrade_rw.go
@@ -20,19 +20,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}

--- a/cmd/platina/mk1/toggle/toggle_rw.go
+++ b/cmd/platina/mk1/toggle/toggle_rw.go
@@ -20,19 +20,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}

--- a/cmd/platina/mk2/lc1/bmc/diag/diagI2c.go
+++ b/cmd/platina/mk2/lc1/bmc/diag/diagI2c.go
@@ -20,7 +20,7 @@ var j [MAXOPS]I
 var s [MAXOPS]R
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var x int
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var chassisType, boardType uint8
 
 const (
@@ -41,13 +41,13 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 

--- a/cmd/platina/mk2/lc1/bmc/ledgpiod/ledgpiod_rw.go
+++ b/cmd/platina/mk2/lc1/bmc/ledgpiod/ledgpiod_rw.go
@@ -21,19 +21,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}
@@ -57,7 +57,7 @@ func (r *reg16) offset() uint8  { return uint8((uintptr(unsafe.Pointer(r)) - reg
 func (r *reg16r) offset() uint8 { return uint8((uintptr(unsafe.Pointer(r)) - regsAddr)) }
 
 func closeMux(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(0)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -66,7 +66,7 @@ func closeMux(h *I2cDev) {
 }
 
 func (r *reg8) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -76,7 +76,7 @@ func (r *reg8) get(h *I2cDev) {
 }
 
 func (r *reg16) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -86,7 +86,7 @@ func (r *reg16) get(h *I2cDev) {
 }
 
 func (r *reg16r) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -96,7 +96,7 @@ func (r *reg16r) get(h *I2cDev) {
 }
 
 func (r *reg8) set(h *I2cDev, v uint8) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -107,7 +107,7 @@ func (r *reg8) set(h *I2cDev, v uint8) {
 }
 
 func (r *reg16) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -119,7 +119,7 @@ func (r *reg16) set(h *I2cDev, v uint16) {
 }
 
 func (r *reg16r) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -138,7 +138,7 @@ func clearJ() {
 }
 
 func readStopped() byte {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 	j[0] = I{true, i2c.Write, 0, i2c.ByteData, data, int(0x98), int(0), 0}
 	err := DoI2cRpc()
 	if err != nil {

--- a/cmd/platina/mk2/lc1/bmc/ucd9090d/ucd9090d_rw.go
+++ b/cmd/platina/mk2/lc1/bmc/ucd9090d/ucd9090d_rw.go
@@ -21,19 +21,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}
@@ -57,7 +57,7 @@ func (r *reg16) offset() uint8  { return uint8((uintptr(unsafe.Pointer(r)) - reg
 func (r *reg16r) offset() uint8 { return uint8((uintptr(unsafe.Pointer(r)) - regsAddr) >> 1) }
 
 func closeMux(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(0)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -66,7 +66,7 @@ func closeMux(h *I2cDev) {
 }
 
 func (r *reg8) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -76,7 +76,7 @@ func (r *reg8) get(h *I2cDev) {
 }
 
 func (r *reg8b) get(h *I2cDev, readLen byte) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 5}
@@ -87,7 +87,7 @@ func (r *reg8b) get(h *I2cDev, readLen byte) {
 }
 
 func (r *reg16) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -97,7 +97,7 @@ func (r *reg16) get(h *I2cDev) {
 }
 
 func (r *reg16r) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -107,7 +107,7 @@ func (r *reg16r) get(h *I2cDev) {
 }
 
 func (r *reg8) set(h *I2cDev, v uint8) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -119,7 +119,7 @@ func (r *reg8) set(h *I2cDev, v uint8) {
 
 /*
 func (r *reg8b) set(h *I2cDev, v []byte) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -129,7 +129,7 @@ func (r *reg8b) set(h *I2cDev, v []byte) {
 }
 */
 func (r *reg16) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -141,7 +141,7 @@ func (r *reg16) set(h *I2cDev, v uint16) {
 }
 
 func (r *reg16r) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -160,7 +160,7 @@ func clearJ() {
 }
 
 func readStopped() byte {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 	j[0] = I{true, i2c.Write, 0, i2c.ByteData, data, int(0x98), int(0), 0}
 	err := DoI2cRpc()
 	if err != nil {

--- a/cmd/platina/mk2/lc1/bmc/upgrade/upgrade_rw.go
+++ b/cmd/platina/mk2/lc1/bmc/upgrade/upgrade_rw.go
@@ -20,19 +20,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}

--- a/cmd/platina/mk2/mc1/bmc/diag/diagI2c.go
+++ b/cmd/platina/mk2/mc1/bmc/diag/diagI2c.go
@@ -20,7 +20,7 @@ var j [MAXOPS]I
 var s [MAXOPS]R
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var x int
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var chassisType, boardType uint8
 
 const (
@@ -41,13 +41,13 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 

--- a/cmd/platina/mk2/mc1/bmc/lceventsd/lceventsd_rw.go
+++ b/cmd/platina/mk2/mc1/bmc/lceventsd/lceventsd_rw.go
@@ -19,19 +19,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}
@@ -54,7 +54,7 @@ func (r *reg16) offset() uint8   { return uint8((uintptr(unsafe.Pointer(r)) - re
 func (r *reg16r) offset() uint8  { return uint8((uintptr(unsafe.Pointer(r)) - regsAddr)) }
 
 func closeMux(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(0)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -63,7 +63,7 @@ func closeMux(h *I2cDev) {
 }
 
 func (r *reg8) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -73,7 +73,7 @@ func (r *reg8) get(h *I2cDev) {
 }
 
 func (r *reg8b) get(h *I2cDev, readLen byte) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -84,7 +84,7 @@ func (r *reg8b) get(h *I2cDev, readLen byte) {
 }
 
 func (r *reg16) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -94,7 +94,7 @@ func (r *reg16) get(h *I2cDev) {
 }
 
 func (r *reg16r) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -104,7 +104,7 @@ func (r *reg16r) get(h *I2cDev) {
 }
 
 func (r *reg8) set(h *I2cDev, v uint8) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -115,7 +115,7 @@ func (r *reg8) set(h *I2cDev, v uint8) {
 }
 
 func (r *reg16) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -127,7 +127,7 @@ func (r *reg16) set(h *I2cDev, v uint16) {
 }
 
 func (r *reg16r) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -146,7 +146,7 @@ func clearJ() {
 }
 
 func readStopped() byte {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 	j[0] = I{true, i2c.Write, 0, i2c.ByteData, data, int(0x98), int(0), 0}
 	DoI2cRpc()
 	return s[0].D[0]

--- a/cmd/platina/mk2/mc1/bmc/ledgpiod/ledgpiod_rw.go
+++ b/cmd/platina/mk2/mc1/bmc/ledgpiod/ledgpiod_rw.go
@@ -21,19 +21,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}
@@ -57,7 +57,7 @@ func (r *reg16) offset() uint8  { return uint8((uintptr(unsafe.Pointer(r)) - reg
 func (r *reg16r) offset() uint8 { return uint8((uintptr(unsafe.Pointer(r)) - regsAddr)) }
 
 func closeMux(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(0)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -66,7 +66,7 @@ func closeMux(h *I2cDev) {
 }
 
 func (r *reg8) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -76,7 +76,7 @@ func (r *reg8) get(h *I2cDev) {
 }
 
 func (r *reg16) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -86,7 +86,7 @@ func (r *reg16) get(h *I2cDev) {
 }
 
 func (r *reg16r) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -96,7 +96,7 @@ func (r *reg16r) get(h *I2cDev) {
 }
 
 func (r *reg8) set(h *I2cDev, v uint8) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -107,7 +107,7 @@ func (r *reg8) set(h *I2cDev, v uint8) {
 }
 
 func (r *reg16) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -119,7 +119,7 @@ func (r *reg16) set(h *I2cDev, v uint16) {
 }
 
 func (r *reg16r) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -138,7 +138,7 @@ func clearJ() {
 }
 
 func readStopped() byte {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 	j[0] = I{true, i2c.Write, 0, i2c.ByteData, data, int(0x98), int(0), 0}
 	err := DoI2cRpc()
 	if err != nil {

--- a/cmd/platina/mk2/mc1/bmc/nct7802yd/nct7802yd_rw.go
+++ b/cmd/platina/mk2/mc1/bmc/nct7802yd/nct7802yd_rw.go
@@ -22,19 +22,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}
@@ -58,7 +58,7 @@ func (r *reg16) offset() uint8  { return uint8(uintptr(unsafe.Pointer(r)) - regs
 func (r *reg16r) offset() uint8 { return uint8(uintptr(unsafe.Pointer(r)) - regsAddr) }
 
 func closeMux(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(0)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -67,7 +67,7 @@ func closeMux(h *I2cDev) {
 }
 
 func (r *reg8) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -77,7 +77,7 @@ func (r *reg8) get(h *I2cDev) {
 }
 
 func (r *reg16) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -87,7 +87,7 @@ func (r *reg16) get(h *I2cDev) {
 }
 
 func (r *reg16r) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -97,7 +97,7 @@ func (r *reg16r) get(h *I2cDev) {
 }
 
 func (r *reg8) set(h *I2cDev, v uint8) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -108,7 +108,7 @@ func (r *reg8) set(h *I2cDev, v uint8) {
 }
 
 func (r *reg16) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -120,7 +120,7 @@ func (r *reg16) set(h *I2cDev, v uint16) {
 }
 
 func (r *reg16r) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -139,7 +139,7 @@ func clearJ() {
 }
 
 func readStopped() byte {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 	j[0] = I{true, i2c.Write, 0, i2c.ByteData, data, int(0x98), int(0), 0}
 	err := DoI2cRpc()
 	if err != nil {

--- a/cmd/platina/mk2/mc1/bmc/qsfpeventsd/qsfpeventsd_rw.go
+++ b/cmd/platina/mk2/mc1/bmc/qsfpeventsd/qsfpeventsd_rw.go
@@ -20,19 +20,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}
@@ -58,7 +58,7 @@ func (r *reg16) offset() uint8   { return uint8((uintptr(unsafe.Pointer(r)) - re
 func (r *reg16r) offset() uint8  { return uint8((uintptr(unsafe.Pointer(r)) - regsAddr)) }
 
 func closeMux(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(0)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -67,7 +67,7 @@ func closeMux(h *I2cDev) {
 }
 
 func (r *reg8) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -77,7 +77,7 @@ func (r *reg8) get(h *I2cDev) {
 }
 
 func (r *reg8b) get(h *I2cDev, readLen byte) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -88,7 +88,7 @@ func (r *reg8b) get(h *I2cDev, readLen byte) {
 }
 
 func (r *reg16) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -98,7 +98,7 @@ func (r *reg16) get(h *I2cDev) {
 }
 
 func (r *reg16r) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -108,7 +108,7 @@ func (r *reg16r) get(h *I2cDev) {
 }
 
 func (r *reg8) set(h *I2cDev, v uint8) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -119,7 +119,7 @@ func (r *reg8) set(h *I2cDev, v uint8) {
 }
 
 func (r *reg16) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -131,7 +131,7 @@ func (r *reg16) set(h *I2cDev, v uint16) {
 }
 
 func (r *reg16r) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -150,7 +150,7 @@ func clearJ() {
 }
 
 func readStopped() byte {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 	j[0] = I{true, i2c.Write, 0, i2c.ByteData, data, int(0x98), int(0), 0}
 	DoI2cRpc()
 	return s[0].D[0]

--- a/cmd/platina/mk2/mc1/bmc/ucd9090d/ucd9090d_rw.go
+++ b/cmd/platina/mk2/mc1/bmc/ucd9090d/ucd9090d_rw.go
@@ -21,19 +21,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}
@@ -57,7 +57,7 @@ func (r *reg16) offset() uint8  { return uint8((uintptr(unsafe.Pointer(r)) - reg
 func (r *reg16r) offset() uint8 { return uint8((uintptr(unsafe.Pointer(r)) - regsAddr) >> 1) }
 
 func closeMux(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(0)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -66,7 +66,7 @@ func closeMux(h *I2cDev) {
 }
 
 func (r *reg8) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -76,7 +76,7 @@ func (r *reg8) get(h *I2cDev) {
 }
 
 func (r *reg8b) get(h *I2cDev, readLen byte) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 5}
@@ -87,7 +87,7 @@ func (r *reg8b) get(h *I2cDev, readLen byte) {
 }
 
 func (r *reg16) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -97,7 +97,7 @@ func (r *reg16) get(h *I2cDev) {
 }
 
 func (r *reg16r) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -107,7 +107,7 @@ func (r *reg16r) get(h *I2cDev) {
 }
 
 func (r *reg8) set(h *I2cDev, v uint8) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -119,7 +119,7 @@ func (r *reg8) set(h *I2cDev, v uint8) {
 
 /*
 func (r *reg8b) set(h *I2cDev, v []byte) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -129,7 +129,7 @@ func (r *reg8b) set(h *I2cDev, v []byte) {
 }
 */
 func (r *reg16) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -141,7 +141,7 @@ func (r *reg16) set(h *I2cDev, v uint16) {
 }
 
 func (r *reg16r) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -160,7 +160,7 @@ func clearJ() {
 }
 
 func readStopped() byte {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 	j[0] = I{true, i2c.Write, 0, i2c.ByteData, data, int(0x98), int(0), 0}
 	err := DoI2cRpc()
 	if err != nil {

--- a/cmd/platina/mk2/mc1/bmc/upgrade/upgrade_rw.go
+++ b/cmd/platina/mk2/mc1/bmc/upgrade/upgrade_rw.go
@@ -20,19 +20,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}

--- a/cmd/platina/mk2/mc1/bmc/w83795d/w83795d_rw.go
+++ b/cmd/platina/mk2/mc1/bmc/w83795d/w83795d_rw.go
@@ -22,19 +22,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}
@@ -67,7 +67,7 @@ func (r *reg16) offset() uint8  { return uint8(uintptr(unsafe.Pointer(r)) - regs
 func (r *reg16r) offset() uint8 { return uint8(uintptr(unsafe.Pointer(r)) - regsAddr) }
 
 func closeMux(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(0)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus2, h.MuxAddr2, 0}
@@ -77,7 +77,7 @@ func closeMux(h *I2cDev) {
 }
 
 func (r *reg8) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -90,7 +90,7 @@ func (r *reg8) get(h *I2cDev) {
 }
 
 func (r *reg16) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -103,7 +103,7 @@ func (r *reg16) get(h *I2cDev) {
 }
 
 func (r *reg16r) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -116,7 +116,7 @@ func (r *reg16r) get(h *I2cDev) {
 }
 
 func (r *reg8) set(h *I2cDev, v uint8) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -130,7 +130,7 @@ func (r *reg8) set(h *I2cDev, v uint8) {
 }
 
 func (r *reg16) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -145,7 +145,7 @@ func (r *reg16) set(h *I2cDev, v uint16) {
 }
 
 func (r *reg16r) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -167,7 +167,7 @@ func clearJ() {
 }
 
 func readStopped() byte {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 	j[0] = I{true, i2c.Write, 0, i2c.ByteData, data, int(0x98), int(0), 0}
 	err := DoI2cRpc()
 	if err != nil {

--- a/cmd/platina/mk2/toggle/toggle_rw.go
+++ b/cmd/platina/mk2/toggle/toggle_rw.go
@@ -20,19 +20,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}

--- a/cmd/w83795d/w83795d_rw.go
+++ b/cmd/w83795d/w83795d_rw.go
@@ -22,19 +22,19 @@ type I struct {
 	RW        i2c.RW
 	RegOffset uint8
 	BusSize   i2c.SMBusSize
-	Data      [34]byte
+	Data      [i2c.BlockMax]byte
 	Bus       int
 	Addr      int
 	Delay     int
 }
 type R struct {
-	D [34]byte
+	D [i2c.BlockMax]byte
 	E error
 }
 
 type I2cReq int
 
-var b = [34]byte{0}
+var b = [i2c.BlockMax]byte{0}
 var i = I{false, i2c.RW(0), 0, 0, b, 0, 0, 0}
 var j [MAXOPS]I
 var r = R{b, nil}
@@ -62,7 +62,7 @@ func (r *reg16) offset() uint8  { return uint8(uintptr(unsafe.Pointer(r)) - regs
 func (r *reg16r) offset() uint8 { return uint8(uintptr(unsafe.Pointer(r)) - regsAddr) }
 
 func closeMux(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(0)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -71,7 +71,7 @@ func closeMux(h *I2cDev) {
 }
 
 func (r *reg8) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -81,7 +81,7 @@ func (r *reg8) get(h *I2cDev) {
 }
 
 func (r *reg16) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -91,7 +91,7 @@ func (r *reg16) get(h *I2cDev) {
 }
 
 func (r *reg16r) get(h *I2cDev) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -101,7 +101,7 @@ func (r *reg16r) get(h *I2cDev) {
 }
 
 func (r *reg8) set(h *I2cDev, v uint8) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -112,7 +112,7 @@ func (r *reg8) set(h *I2cDev, v uint8) {
 }
 
 func (r *reg16) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -124,7 +124,7 @@ func (r *reg16) set(h *I2cDev, v uint16) {
 }
 
 func (r *reg16r) set(h *I2cDev, v uint16) {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 
 	data[0] = byte(h.MuxValue)
 	j[x] = I{true, i2c.Write, 0, i2c.ByteData, data, h.MuxBus, h.MuxAddr, 0}
@@ -143,7 +143,7 @@ func clearJ() {
 }
 
 func readStopped() byte {
-	var data = [34]byte{0, 0, 0, 0}
+	var data = [i2c.BlockMax]byte{0, 0, 0, 0}
 	j[0] = I{true, i2c.Write, 0, i2c.ByteData, data, int(0x98), int(0), 0}
 	err := DoI2cRpc()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/platinasystems/fdt v0.0.0-20181004054827-3416b99a7d82
 	github.com/platinasystems/go-redis-server v0.0.0-20181030193423-fcb8fa742b73
 	github.com/platinasystems/gpio v0.0.0-20181120172958-aa9a44e83566
-	github.com/platinasystems/i2c v1.1.0
+	github.com/platinasystems/i2c v1.2.0
 	github.com/platinasystems/liner v0.0.0-20170801164932-8dd8fbd0e16d
 	github.com/platinasystems/log v1.2.1
 	github.com/platinasystems/memio v0.0.0-20181109233200-08a432045d57


### PR DESCRIPTION
The kernel has changed to enforce the proper SMBUS I/O size, which
is 32 bytes. We were doing 33 byte operations which were previously
allowed but are now rejected by the kernel.

Signed-off-by: Kevin Paul Herbert <kph@platinasystems.com>