### PR TITLE
femtocom: Fix some typos

### DIFF
--- a/cmd/femtocom/femtocom.go
+++ b/cmd/femtocom/femtocom.go
@@ -11,9 +11,9 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/platinasystems/goes/lang"
 	"github.com/platinasystems/goes/internal/flags"
 	"github.com/platinasystems/goes/internal/parms"
+	"github.com/platinasystems/goes/lang"
 )
 
 type Command struct{}
@@ -118,9 +118,9 @@ func (Command) Main(args ...string) error {
 		"odd":  syscall.PARENB | syscall.PARODD,
 		"even": syscall.PARENB,
 		"none": 0,
-	}[parm.ByName["-partity"]]
+	}[parm.ByName["-parity"]]
 	if !found {
-		return fmt.Errorf("%s: invalid parity", parm.ByName["-partity"])
+		return fmt.Errorf("%s: invalid parity", parm.ByName["-parity"])
 	}
 
 	if len(parm.ByName["-databits"]) == 0 {
@@ -131,9 +131,9 @@ func (Command) Main(args ...string) error {
 		"6": syscall.CS6,
 		"7": syscall.CS7,
 		"8": syscall.CS8,
-	}[parm.ByName["-databites"]]
+	}[parm.ByName["-databits"]]
 	if !found {
-		return fmt.Errorf("%s: invalid databits", parm.ByName["-databites"])
+		return fmt.Errorf("%s: invalid databits", parm.ByName["-databits"])
 	}
 
 	if len(parm.ByName["-stopbits"]) == 0 {


### PR DESCRIPTION
Fix -partity and -databites typos; make it work.

Signed-off-by: Kevin Paul Herbert <kph@platinasystems.com>