### PR TITLE
Fix swapped short and long descriptions for "cat" and "mac-ll"

### DIFF
--- a/cmd/cat/cat.go
+++ b/cmd/cat/cat.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/platinasystems/goes/lang"
 	"github.com/platinasystems/goes/internal/url"
+	"github.com/platinasystems/goes/lang"
 )
 
 type Command struct{}
@@ -22,11 +22,6 @@ func (Command) Usage() string {
 }
 
 func (Command) Man() lang.Alt {
-	return lang.Alt{
-		lang.EnUS: "print concatenated files",
-	}
-}
-func (Command) Apropos() lang.Alt {
 	return lang.Alt{
 		lang.EnUS: `
 DESCRIPTION
@@ -40,6 +35,11 @@ EXAMPLES
 
 	cat
 		Copy standard input to standard output.`,
+	}
+}
+func (Command) Apropos() lang.Alt {
+	return lang.Alt{
+		lang.EnUS: "print concatenated files",
 	}
 }
 

--- a/cmd/mac_ll/mac_ll.go
+++ b/cmd/mac_ll/mac_ll.go
@@ -18,20 +18,20 @@ type Command struct{}
 
 func (Command) Man() lang.Alt {
 	return lang.Alt{
-		lang.EnUS: "convert mac addresss to IPv6 link-local",
+		lang.EnUS: `
+DESCRIPTION
+        Convert a 6 byte MAC address to an IPv6 link-local.
+
+        Without any args, show the base MAC address plus link-local.
+
+        <mac>    Convert the MAC address isIPv6 link-local.`,
 	}
 }
 func (Command) String() string { return "mac-ll" }
 func (Command) Usage() string  { return "mac-ll <mac>" }
 func (Command) Apropos() lang.Alt {
 	return lang.Alt{
-		lang.EnUS: `
-DESCRIPTION 
-        Convert a 6 byte MAC address to an IPv6 link-local.
-
-        Without any args, show the base MAC address plus link-local.
-
-        <mac>    Convert the MAC address isIPv6 link-local.`,
+		lang.EnUS: "convert mac addresss to IPv6 link-local",
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Frank Yang <fyang@platinasystems.com>